### PR TITLE
Improve GLORIA-USEEIO commodity matching

### DIFF
--- a/import_emission_factors/concordances/GLORIA_country_concordance.csv
+++ b/import_emission_factors/concordances/GLORIA_country_concordance.csv
@@ -252,6 +252,6 @@ Venezuela,VE,VEN
 Vietnam,VN,VNM
 Wallis and Futuna,WF,XAS
 West Bank administered by Israel,WE,XAS
-Yemen (Republic of Yemen),YE,DYE
+Yemen (Republic of Yemen),YE,YEM
 Zambia,ZM,ZMB
 Zimbabwe,ZW,ZWE

--- a/import_emission_factors/concordances/GLORIA_country_concordance.csv
+++ b/import_emission_factors/concordances/GLORIA_country_concordance.csv
@@ -83,7 +83,7 @@ Finland,FI,FIN
 France,FR,FRA
 French Guiana,GF,XAM
 French Polynesia,PF,XAS
-French Southern and Antarctic Lands,TF,
+French Southern and Antarctic Lands,TF,XAF
 Gabon,GA,GAB
 Gambia,GM,GMB
 Gaza Strip administered by Israel,GZ,XAS
@@ -101,7 +101,7 @@ Guinea,GN,GIN
 Guinea-Bissau,GW,XAF
 Guyana,GY,XAM
 Haiti,HT,HTI
-Heard Island and McDonald Islands,HM,
+Heard Island and McDonald Islands,HM,XAS
 Holy See (Vatican City),VA,XEU
 Honduras,HN,HND
 Hong Kong,HK,HKG
@@ -176,8 +176,8 @@ Other Asia and Pacific (International Services Trade),,XAS
 Other Europe (International Services Trade),,XEU
 Other Middle East (International Services Trade),,XAS
 Other South And Central America (International Services Trade),,XAM
-Other Western Hemisphere,,
-"Other Western Hemisphere, Other (International Services Trade)",,
+Other Western Hemisphere,,XAM
+"Other Western Hemisphere, Other (International Services Trade)",,XAM
 Pakistan,PK,PAK
 Palau,PW,XAS
 Panama,PA,PAN
@@ -193,7 +193,7 @@ Reunion,RE,XAF
 Romania,RO,ROU
 Russia,RU,RUS
 Rwanda,RW,RWA
-Saint Helena,SH,
+Saint Helena,SH,XAF
 Saint Kitts and Nevis,KN,XAM
 Saint Lucia,LC,XAM
 Saint Pierre and Miquelon,PM,XAM

--- a/import_emission_factors/concordances/GLORIA_to_useeio2_commodity_concordance.csv
+++ b/import_emission_factors/concordances/GLORIA_to_useeio2_commodity_concordance.csv
@@ -1,4 +1,4 @@
-GLORIA Sector,USEEIO_Detail_2012,USEEIO_Detail_2017
+﻿GLORIA Sector,USEEIO_Detail_2012,USEEIO_Detail_2017
 Growing wheat,1111B0,1111B0
 Growing maize,1111B0,1111B0
 Growing cereals n.e.c,1111B0,1111B0
@@ -44,6 +44,7 @@ Other non-ferrous ores,2122A0,2122A0
 "Quarrying of stone, sand and clay",2123A0,2123A0
 Chemical and fertilizer minerals,2123A0,2123A0
 Extraction of salt,2123A0,2123A0
+Mining and quarrying n.e.c.; services to mining,213111,213111
 Mining and quarrying n.e.c.; services to mining,21311A,21311A
 Beef meat,31161A,31161A
 Sheep meat,31161A,31161A
@@ -105,13 +106,15 @@ Printing,323110,323110
 Printing,323120,323120
 Coke oven products,324190,324190
 Refined petroleum products,324110,324110
-Refined petroleum products,325120,325120
 Refined petroleum products,324121,324121
 Refined petroleum products,324122,324122
 Refined petroleum products,324190,324190
 Nitrogenous fertilizers,325310,325310
 Non-nitrogenous and mixed fertilizers,325310,325310
 Basic petrochemical products,325110,325110
+Basic petrochemical products,325120,325120
+Basic petrochemical products,3252A0,3252A0
+Basic petrochemical products,325211,325211
 Basic inorganic chemicals,325180,325180
 Basic organic chemicals,325190,325190
 Pharmaceuticals and medicinal products,325411,325411
@@ -123,7 +126,6 @@ Pharmaceuticals and medicinal products,325414,325414
 "Dyes, paints, glues, detergents and other chemical products",325620,325620
 "Dyes, paints, glues, detergents and other chemical products",325910,325910
 "Dyes, paints, glues, detergents and other chemical products",325130,325130
-"Dyes, paints, glues, detergents and other chemical products",325211,325211
 "Dyes, paints, glues, detergents and other chemical products",325320,325320
 "Dyes, paints, glues, detergents and other chemical products",325510,325510
 "Dyes, paints, glues, detergents and other chemical products",3259A0,3259A0
@@ -149,27 +151,31 @@ Other non-metallic mineral products n.e.c.,327991,327991
 Other non-metallic mineral products n.e.c.,327992,327992
 Other non-metallic mineral products n.e.c.,327993,327993
 Other non-metallic mineral products n.e.c.,327999,327999
-Basic iron and steel,331510,331510
-Basic iron and steel,33211A,33211A
-Basic iron and steel,331520,331520
 Basic iron and steel,331110,331110
 Basic iron and steel,331200,331200
+Basic iron and steel,331510,331510
 Basic aluminium,331313,331313
-Basic aluminium,331314,331314
 Basic aluminium,33131B,33131B
 Basic Copper,331420,331420
 Basic Copper,331410,331410
+Basic Copper,331520,331520
 Basic Gold,331410,331410
+Basic Gold,331490,331490
+Basic lead/zinc/silver,331410,331410
 Basic lead/zinc/silver,331490,331490
 Basic lead/zinc/silver,331520,331520
+Basic nickel,331410,331410
 Basic nickel,331490,331490
 Basic nickel,331520,331520
+Basic tin,331410,331410
 Basic tin,331490,331490
 Basic tin,331520,331520
+Basic non-ferrous metals n.e.c.,331410,331410
 Basic non-ferrous metals n.e.c.,331520,331520
 Basic non-ferrous metals n.e.c.,331490,331490
 Fabricated metal products,332119,332119
 Fabricated metal products,332114,332114
+Fabricated metal products,33211A,33211A
 Fabricated metal products,332200,332200
 Fabricated metal products,332410,332410
 Fabricated metal products,332310,332310
@@ -193,8 +199,6 @@ Machinery and equipment,333120,333120
 Machinery and equipment,333130,333130
 Machinery and equipment,333242,333242
 Machinery and equipment,33329A,33329A
-Machinery and equipment,333314,333314
-Machinery and equipment,333316,333316
 Machinery and equipment,333318,333318
 Machinery and equipment,333413,333413
 Machinery and equipment,333414,333414
@@ -243,6 +247,8 @@ Other transport equipment,336999,336999
 Repair and installation of machinery and equipment (service),811200,811200
 Repair and installation of machinery and equipment (service),811300,811300
 Repair and installation of machinery and equipment (service),811400,811400
+Computers; electronic products; optical and precision instruments,333314,333314
+Computers; electronic products; optical and precision instruments,333316,333316
 Computers; electronic products; optical and precision instruments,334111,334111
 Computers; electronic products; optical and precision instruments,334112,334112
 Computers; electronic products; optical and precision instruments,334118,334118
@@ -316,12 +322,10 @@ Distribution of gaseous fuels through mains,221200,221200
 "Waste collection, treatment, and disposal",562998,562000
 Materials recovery,562920,562000
 Materials recovery,S00401,S00401
-Materials recovery,S00402,S00402
 Building construction,230301,230301
 Building construction,230302,230302
 Building construction,233210,233210
 Building construction,233230,233230
-Building construction,233240,233240
 Building construction,233262,233262
 Building construction,2332A0,2332A0
 Building construction,2332D0,2332D0
@@ -329,6 +333,7 @@ Building construction,233411,233411
 Building construction,233412,233412
 Building construction,2334A0,2334A0
 Civil engineering construction,2332C0,2332C0
+Civil engineering construction,233240,233240
 Wholesale and retail trade; repair of motor vehicles and motorcycles,423100,423100
 Wholesale and retail trade; repair of motor vehicles and motorcycles,423400,423400
 Wholesale and retail trade; repair of motor vehicles and motorcycles,423600,423600
@@ -355,7 +360,7 @@ Rail transport,482000,482000
 Transport via pipeline,486000,486000
 Water transport,483000,483000
 Air transport,481000,481000
-Services to transport,,
+Services to transport,493000,493000
 Postal and courier services,492000,492000
 Hospitality,721000,721000
 Hospitality,722110,722110
@@ -385,10 +390,6 @@ Finance and insurance,52A000,52A000
 Property and real estate,531HSO,531HSO
 Property and real estate,531HST,531HST
 Property and real estate,531ORE,531ORE
-Property and real estate,532100,532100
-Property and real estate,532400,532400
-Property and real estate,532A00,532A00
-Property and real estate,533000,533000
 "Professional, scientific and technical services",541100,541100
 "Professional, scientific and technical services",541200,541200
 "Professional, scientific and technical services",541300,541300
@@ -403,6 +404,10 @@ Property and real estate,533000,533000
 "Professional, scientific and technical services",541920,541920
 "Professional, scientific and technical services",541940,541940
 "Professional, scientific and technical services",5419A0,5419A0
+Administrative services,532100,532100
+Administrative services,532400,532400
+Administrative services,532A00,532A00
+Administrative services,533000,533000
 Administrative services,561100,561100
 Administrative services,561200,561200
 Administrative services,561300,561300
@@ -411,19 +416,15 @@ Administrative services,561500,561500
 Administrative services,561600,561600
 Administrative services,561700,561700
 Administrative services,561900,561900
-Government; social security; defence; public order,GSLGE,GSLGE
-Government; social security; defence; public order,GSLGH,GSLGH
 Government; social security; defence; public order,GSLGO,GSLGO
-Government; social security; defence; public order,S00101,S00101
-Government; social security; defence; public order,S00201,S00201
 Government; social security; defence; public order,S00102,S00102
 Government; social security; defence; public order,S00203,S00203
-Government; social security; defence; public order,S00202,S00202
 Government; social security; defence; public order,S00500,S00500
 Government; social security; defence; public order,S00600,S00600
 Education,611100,611100
 Education,611A00,611A00
 Education,611B00,611B00
+Education,GSLGE,GSLGE
 Human health and social work activities,621100,621100
 Human health and social work activities,621200,621200
 Human health and social work activities,621300,621300
@@ -437,6 +438,7 @@ Human health and social work activities,623B00,623B00
 Human health and social work activities,624100,624100
 Human health and social work activities,624400,624400
 Human health and social work activities,624A00,624A00
+Human health and social work activities,GSLGH,GSLGH
 "Arts, entertainment and recreation",711100,711100
 "Arts, entertainment and recreation",711200,711200
 "Arts, entertainment and recreation",711500,711500
@@ -453,4 +455,3 @@ Other services,813100,813100
 Other services,813A00,813A00
 Other services,813B00,813B00
 Other services,814000,814000
-Other services,S00300,S00300

--- a/import_emission_factors/concordances/GLORIA_to_useeio2_commodity_concordance.csv
+++ b/import_emission_factors/concordances/GLORIA_to_useeio2_commodity_concordance.csv
@@ -361,6 +361,7 @@ Transport via pipeline,486000,486000
 Water transport,483000,483000
 Air transport,481000,481000
 Services to transport,493000,493000
+Services to transport,48A000,48A000
 Postal and courier services,492000,492000
 Hospitality,721000,721000
 Hospitality,722110,722110
@@ -371,8 +372,10 @@ Publishing,511120,511120
 Publishing,511130,511130
 Publishing,5111A0,5111A0
 Publishing,511200,511200
-Telecommunications,515100,515100
-Telecommunications,515200,515200
+Publishing,512100,512100
+Publishing,512200,512200
+Publishing,515100,515100
+Publishing,515200,515200
 Telecommunications,517110,517110
 Telecommunications,517210,517210
 Telecommunications,517A00,517A00

--- a/import_emission_factors/concordances/GLORIA_to_useeio2_commodity_concordance.csv
+++ b/import_emission_factors/concordances/GLORIA_to_useeio2_commodity_concordance.csv
@@ -420,6 +420,8 @@ Administrative services,561600,561600
 Administrative services,561700,561700
 Administrative services,561900,561900
 Government; social security; defence; public order,GSLGO,GSLGO
+Government; social security; defence; public order,491000,491000
+Government; social security; defence; public order,S00101,S00101
 Government; social security; defence; public order,S00102,S00102
 Government; social security; defence; public order,S00203,S00203
 Government; social security; defence; public order,S00500,S00500

--- a/import_emission_factors/data/gloria_country_names.csv
+++ b/import_emission_factors/data/gloria_country_names.csv
@@ -41,7 +41,7 @@ DEU,Germany
 DJI,Djibouti
 DNK,Denmark
 DOM,Dominican Republic
-DYE,DR Yemen (Aden)
+YEM,Yemen (Republic of Yemen)
 DZA,Algeria
 ECU,Ecuador
 EGY,Egypt

--- a/import_emission_factors/generate_import_factors.py
+++ b/import_emission_factors/generate_import_factors.py
@@ -302,8 +302,7 @@ def map_mrio_countires(df):
     path = conPath / f'{source}_country_concordance.csv'
     codes = pd.read_csv(path, dtype=str, usecols=['Country', 'CountryCode'])
     df = df.merge(codes, on='Country', how='left', validate='m:1')
-    missing = (set(df[df.isnull().any(axis=1)]['Country'])
-               - set(codes['Country']))
+    missing = (set(df[df.isnull().any(axis=1)]['Country']))
     if len(missing) > 0:
         print(f'WARNING: missing countries in correspondence: {missing}')
 

--- a/import_emission_factors/generate_import_factors.py
+++ b/import_emission_factors/generate_import_factors.py
@@ -128,6 +128,9 @@ def generate_import_emission_factors(years: list, schema=2012, calc_tiva=False):
                                    on=['CountryCode', 'BEA Detail', 'BEA Summary'])
                             .merge(mrio_country_names, on='CountryCode', validate='m:1')
                             )
+        missing = set(imports_agg['CountryCode']) - set(agg['CountryCode'])
+        if(len(missing) > 0):
+            print(f'WARNING: missing countries in correspondence: {missing}')
         ## NOTE: If in future more physical data are brought in, the code 
         ##       is unable to distinguish and sort out mismatches by detail/
         ##       summary sectors.

--- a/import_emission_factors/gloria_helpers.py
+++ b/import_emission_factors/gloria_helpers.py
@@ -35,10 +35,11 @@ def clean_gloria_M_matrix(M, fields_to_rename, **kwargs):
     # filter dataset with sectors that have reasonable output to avoid outliers
     output = pull_mrio_data(year, 'output')
     M_df = (M_df.merge(output, how = 'left')
-            .query('Output > 1')
+            .query('Output > 1000')
             .reset_index(drop=True)
             .drop(columns='Output')
             )
+    ## ^^ Note that dropping rows can impact the trade contributions later
 
     drop_list = [
         # ('CHL', 'Motor vehicles, trailers and semi-trailers'),
@@ -47,7 +48,7 @@ def clean_gloria_M_matrix(M, fields_to_rename, **kwargs):
         # ('HKG', 'Plastic products'),
         # ('HKG', 'Quarrying of stone, sand and clay'),
         # ('HKG', 'Chemical and fertilizer minerals'),
-        ('SGP', 'Mining and quarrying n.e.c.; services to mining')
+        # ('SGP', 'Mining and quarrying n.e.c.; services to mining')
         ]
     for i in drop_list:
         print(f'Dropping outliers for {": ".join(i)}')

--- a/import_emission_factors/scripts/check_for_missing_USEEIO_sectors_in_crosswalk.py
+++ b/import_emission_factors/scripts/check_for_missing_USEEIO_sectors_in_crosswalk.py
@@ -1,0 +1,22 @@
+'''
+Can check for USEEIO model sectors that do not have mappings in crosswalk
+CAUTION: DOES NOT YET DYNAMICALLY CHANGE IEF Source; its grabbing source that is set in generate_import_factors.py
+'''
+
+import pandas as pd
+from import_emission_factors.generate_import_factors import get_mrio_to_useeio_concordance
+
+schema = 2017
+
+
+cw = get_mrio_to_useeio_concordance(schema)
+useeio_sectors_in_cw = set(pd.unique(cw.get('BEA Detail').values))
+
+useeio_sectors = pd.read_csv("import_emission_factors/concordances/useeio_internal_concordance.csv")
+useeio_sectors = set(pd.unique(useeio_sectors.get('USEEIO_Detail_2017')))
+
+sector_missing_in_cw = useeio_sectors - useeio_sectors_in_cw
+
+print(sector_missing_in_cw)
+
+


### PR DESCRIPTION
 Assume ISIC v4 for mapping. Check and use ISIC v4 manual along with NAICS 2017 index to check more closely for product correspondence

- Add Well drilling match to mining and quarrying n.e.c.; services to mining
- match compressed gases, synthetic rubber and plastics to Basic petrochemical products per ISIC v4 manual which includes "manufacture of liquefied or compressed inorganic industrial or medical gases"
- Remove nonferrous metal casts from Basic iron and steel -Match 'All other forging, stamping, and sintering' to fabricated metal products and not basic iron and steel 
- Add match for 331410 to Basic Pb/Zn/Ag, Basic Ni, Basic Sn,Basic non-ferrous because 331410 includes all metals except Fe and Al
 -Add 331520 to all metals except Fe and Al and also not Au because no gold casts found
- Match optical instrument and photography (333314,333316) to Computers; electronic products; optical and precision instruments instead of to Machinery and equipment
- Remove mapping of used goods to materials recovery
- Change Utilities construction to Civil Engineering, not Building Construction
- Match 493000 to Services to transport because 493000 includes logistics
- Change Vehicle rental and leasing, Commercial equipment rental, Consumer goods and general rental centers, and
Lessors of nonfinancial intangible assets to Adminstrative services from Property and real estate, per Section N Adminstrative and support service activities of ISIC v4
- Change State and local government hospitals and health services mapping to Human heath and social work instead of Government
- Change State and local government educational services to Education instead of Government
- Move radio, television to Publishing and add Sound recording and movies
- Add 48A000 (sight seeing and transport services) to Services to transport
